### PR TITLE
Clarification of array example

### DIFF
--- a/site/content/tutorial/02-reactivity/04-updating-arrays-and-objects/app-a/App.svelte
+++ b/site/content/tutorial/02-reactivity/04-updating-arrays-and-objects/app-a/App.svelte
@@ -1,8 +1,8 @@
 <script>
 	let numbers = [1, 2, 3, 4];
 
-	function addNumber() {
-		numbers.push(numbers.length + 1);
+	function addNumber(value) {
+		numbers.push(value);
 	}
 
 	$: sum = numbers.reduce((t, n) => t + n, 0);

--- a/site/content/tutorial/02-reactivity/04-updating-arrays-and-objects/app-b/App.svelte
+++ b/site/content/tutorial/02-reactivity/04-updating-arrays-and-objects/app-b/App.svelte
@@ -1,8 +1,8 @@
 <script>
 	let numbers = [1, 2, 3, 4];
 
-	function addNumber() {
-		numbers = [...numbers, numbers.length + 1];
+	function addNumber(value) {
+		numbers = [...numbers, value];
 	}
 
 	$: sum = numbers.reduce((t, n) => t + n, 0);

--- a/site/content/tutorial/02-reactivity/04-updating-arrays-and-objects/text.md
+++ b/site/content/tutorial/02-reactivity/04-updating-arrays-and-objects/text.md
@@ -7,8 +7,8 @@ Because Svelte's reactivity is triggered by assignments, using array methods lik
 One way to fix that is to add an assignment that would otherwise be redundant:
 
 ```js
-function addNumber() {
-	numbers.push(numbers.length + 1);
+function addNumber(value) {
+	numbers.push(value);
 	numbers = numbers;
 }
 ```
@@ -16,8 +16,8 @@ function addNumber() {
 But there's a more *idiomatic* solution:
 
 ```js
-function addNumber() {
-	numbers = [...numbers, numbers.length + 1];
+function addNumber(value) {
+	numbers = [...numbers, value];
 }
 ```
 


### PR DESCRIPTION
In the array example it was a bit confusing that the length of the array was used to add a new value.

I think using a `value` var makes the example a lot more obvious for all audiences.